### PR TITLE
CI & packaging fixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,8 +5,6 @@ message = release {new_version}
 tag = False
 tag_name = {new_version}
 
-[bumpversion:file:conda.recipe/meta.yaml]
-
 [bumpversion:file:setup.py]
 
 [bumpversion:file:src/jupyter_contrib_core/__init__.py]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ environment:
       PYTHON_HOME: C:\Python34
       PYTHON_VERSION: '3.4'
       PYTHON_ARCH: '32'
-    - TOXENV: 'py35-notebook,codecov'
+    - TOXENV: 'py35-notebook'
       TOXPYTHON: C:\Python35\python.exe
       PYTHON_HOME: C:\Python35
       PYTHON_VERSION: '3.5'
@@ -60,7 +60,7 @@ test_script:
   - '%PYTHON_HOME%\Scripts\tox -e %TOXENV%'
 
 after_test:
-  - '%PYTHON_HOME%\Scripts\tox -e codecov'
+  - cmd: '%PYTHON_HOME%\Scripts\tox -e codecov || (echo "codecov failed :(" && cmd /c "exit /b 0")'
 on_failure:
   - ps: dir "env:"
   - ps: get-content .tox\*\log\*

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,15 +1,12 @@
-{% set version = '0.3.0' %}
-
 package:
   name: jupyter_contrib_core
-  version: {{ version }}
+  version: {{ GIT_DESCRIBE_TAG }}
 
 source:
   git_url: ../
-  git_tag: {{ version }}
 
 build:
-  number: 0
+  number: {{ GIT_DESCRIBE_NUMBER }}
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ commands =
 skip_install = true
 deps = coveralls
 commands =
-    coverage combine
+    coverage combine --append
     coverage report
     coveralls []
 
@@ -66,7 +66,7 @@ skip_install = true
 deps =
     codecov
 commands =
-    coverage combine
+    coverage combine --append
     coverage report
     coverage xml --ignore-errors
     codecov []
@@ -83,7 +83,7 @@ commands =
     ; tox doesn't run commands through a shell (makes windows inconsistent)
     ; So to get wildcard expansion, run through bash.
     ; Travis is the only place this env should be run, so it's ok to use bash.
-    bash -c \"coverage combine */.coverage\"
+    bash -c \"coverage combine --append */.coverage\"
     coverage report
     coveralls
 
@@ -91,7 +91,7 @@ commands =
 skip_install = true
 deps = coverage
 commands =
-    coverage combine
+    coverage combine --append
     coverage report
     coverage html
 


### PR DESCRIPTION
- fix appveyor py35 env to match others
- attempt to get appveyor to pass even if codecov fails
- use `coverage combine` with `--append` flag, required since 4.2
