### PR TITLE
import ArgumentConflict from notebook.extension

### DIFF
--- a/src/jupyter_contrib_core/notebook_compat/serverextensions.py
+++ b/src/jupyter_contrib_core/notebook_compat/serverextensions.py
@@ -3,9 +3,9 @@
 
 try:
     from notebook.serverextensions import (
-        ArgumentConflict, ToggleServerExtensionApp,
-        toggle_serverextension_python,
+        ToggleServerExtensionApp, toggle_serverextension_python,
     )
+    from notebook.extensions import ArgumentConflict
 except ImportError:
     from ._compat.serverextensions import (
         ArgumentConflict, ToggleServerExtensionApp,

--- a/src/jupyter_contrib_core/notebook_compat/serverextensions.py
+++ b/src/jupyter_contrib_core/notebook_compat/serverextensions.py
@@ -1,16 +1,23 @@
 # -*- coding: utf-8 -*-
 """Shim providing notebook.serverextensions stuff for pre 4.2 versions."""
 
-try:
+try:  # notebook >= 4.2
     from notebook.serverextensions import (
         ToggleServerExtensionApp, toggle_serverextension_python,
     )
-    from notebook.extensions import ArgumentConflict
-except ImportError:
+except ImportError:  # notebook <4.2
     from ._compat.serverextensions import (
-        ArgumentConflict, ToggleServerExtensionApp,
-        toggle_serverextension_python,
+        ToggleServerExtensionApp, toggle_serverextension_python,
     )
+
+try:
+    from notebook.extensions import ArgumentConflict  # notebook >= 5.0
+except ImportError:
+    try:
+        from notebook.serverextensions import ArgumentConflict  # notebook 4.2.x
+    except ImportError:
+        from ._compat.serverextensions import ArgumentConflict  # notebook < 4.2
+
 
 __all__ = [
     'ArgumentConflict', 'ToggleServerExtensionApp',


### PR DESCRIPTION
After notebook 5.0, the `ArgumentConflict` class is moved to `notebook.extensions`.

This commit will make dependencies of jupyter_contrib_core (e.g.: jupyter_nbextensions_configurator) to import the right `ToggleServerExtensionApp` and `toggle_serverextension_python`, which is provided by `notebook.serverextensions`, instead of `jupyter_contrib_core.notebook_compat._compat.serverextensions`.

Before this commit, the [`toggle_serverextension_python` function](https://github.com/Jupyter-contrib/jupyter_contrib_core/blob/5ba0d30ec0779a3098066c55df06088cc7b6c464/src/jupyter_contrib_core/notebook_compat/_compat/serverextensions.py#L74) will configure serverextension item with `server_extensions` in the `jupyter_notebook_config.json`. However, the `server_extensions` key is depercated in notebook 5.0 and later, which is replaced by `nbserver_extensions`.