### PR TITLE
do not depend on deprecated nose

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -8,7 +8,7 @@ from __future__ import (
 import logging
 from unittest import TestCase
 
-import nose.tools as nt
+import pytest
 from traitlets.tests.utils import check_help_all_output, check_help_output
 
 from jupyter_contrib_core.application import main as main_app
@@ -59,5 +59,5 @@ class AppTest(TestCase):
         check_help_output(app_module, [])
         check_help_all_output(app_module, [])
         # sys.exit should be called if no argv specified
-        with nt.assert_raises(SystemExit):
+        with pytest.raises(SystemExit):
             main_app([])

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ deps =
     notebook50: https://github.com/jupyter/notebook/archive/5.0.0.zip
     notebookmaster: https://github.com/jupyter/notebook/archive/master.zip
     notebook: notebook
+    pytest
 commands =
     {posargs:coverage run --source=src -m nose -vv tests}
 


### PR DESCRIPTION
nose will stop working with upcoming python version, thus its usage should be avoided.