### PR TITLE
Remove the `scripts` portion of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,9 +63,6 @@ Common utilities for jupyter-contrib projects. Includes:
                 'jupyter-contrib = jupyter_contrib_core.application:main',  # noqa
             ],
         },
-        scripts=[os.path.join('scripts', p) for p in [
-            'jupyter-contrib',
-        ]],
         classifiers=[
             'Intended Audience :: End Users/Desktop',
             'Intended Audience :: Science/Research',


### PR DESCRIPTION
Scripts is deprecated by entry_points and when both exist it causes errors for some PEP-compliant installers.

some details here: bazelbuild/rules_python#765 (comment)